### PR TITLE
chore(release): sprout: version 0.0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "edera-sprout-boot"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "edera-sprout-build",
@@ -82,18 +82,18 @@ dependencies = [
 
 [[package]]
 name = "edera-sprout-build"
-version = "0.0.24"
+version = "0.0.25"
 
 [[package]]
 name = "edera-sprout-config"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "edera-sprout-eficore"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 
 [workspace.package]
 license = "Apache-2.0"
-version = "0.0.24"
+version = "0.0.25"
 homepage = "https://sprout.edera.dev"
 repository = "https://github.com/edera-dev/sprout"
 edition = "2024"


### PR DESCRIPTION
This will mark the current version as v0.0.25 and prepare things for tag and release.