### PR TITLE
Use jaarg alloc-less API, removing BTreeMap middleman.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "jaarg"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b216e5405f7e759ee0d16007f9d5c3346f9803a2e86cf01fc8df8baac43d0fa"
+checksum = "534d589df1ef528a238f4bc4b1db081a1280f3aedf2695fd8971e9853a7fa4f6"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ default-features = false
 features = ["alloc"]
 
 [workspace.dependencies.jaarg]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 features = ["alloc"]
 


### PR DESCRIPTION
The current jaarg usage uses the BTreeMap API, this PR moves to the base parsing API which removes the loop and BTreeMap lookup element of argument handling. There's still some string copies to deal with handler scope but that's okay as the map API was internally copying strings anyway, and this means string IDs can be replaced with a simple enum.