### PR TITLE
fix(workflows): disable artifact publish attestation for pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,3 +53,4 @@ jobs:
       with:
         subject-name: artifacts.zip
         subject-digest: "sha256:${{ steps.upload.outputs.artifact-digest }}"
+      if: github.event_name != 'pull_request'


### PR DESCRIPTION
PR #41 failed because the PR is from a fork and thus it can't attest artifacts in this repository. We don't need to attest PR artifacts, so disable that.